### PR TITLE
fixed ChipInfo_GetChipType() can not detect CC2630 correctly, because missing a "break" .

### DIFF
--- a/driverlib/chipinfo.c
+++ b/driverlib/chipinfo.c
@@ -145,6 +145,7 @@ ChipInfo_GetChipType( void )
       case 0x4 :
       case 0xC :
          chipType = CHIP_TYPE_CC2630 ;
+         break;	// missing in "v2.24.03.17272"
       case 0x1 :
       case 0x9 :
          chipType = CHIP_TYPE_CC2640 ;

--- a/startup_files/ccfg.c
+++ b/startup_files/ccfg.c
@@ -205,8 +205,8 @@
 #endif
 
 #ifndef SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE
-// #define SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE       0x00       // Access disabled
-#define SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE          0xC5       // Access enabled if also enabled in FCFG
+#define SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE       0x00       // Access disabled
+// #define SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE          0xC5       // Access enabled if also enabled in FCFG
 #endif
 
 #ifndef SET_CCFG_CCFG_TAP_DAP_0_PRCM_TAP_ENABLE
@@ -215,8 +215,8 @@
 #endif
 
 #ifndef SET_CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE
-// #define SET_CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE      0x00       // Access disabled
-#define SET_CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE         0xC5       // Access enabled if also enabled in FCFG
+#define SET_CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE      0x00       // Access disabled
+// #define SET_CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE         0xC5       // Access enabled if also enabled in FCFG
 #endif
 
 #ifndef SET_CCFG_CCFG_TAP_DAP_1_PBIST2_TAP_ENABLE


### PR DESCRIPTION
    This issue come from main() -> netstack_init() ->  rf_core_set_modesel() and call  ChipInfo_GetChipType() to determine how to setting RFCMODESEL, my custom board run with CC2630, but  ChipInfo_GetChipType() return CC2640, so rf_core_set_modesel() can not find correct chip_type, the result is contiki can not fire up the CC2630 RF part.
This issue will not happen if running with CC2650, I think that why no one complaint. and I have found TI have fixed the issue in the new version cc26xxxware
[http://dev.ti.com/tirex/content/simplelink_cc13x0_sdk_1_30_00_06/docs/driverlib_cc13xx_cc26xx/cc26x0/driverlib/group___chip_info.html#ga19e33d5c3c229bf27de7e9d68334b007]

Cai.

